### PR TITLE
Support "(?x)" in language pattern regexes

### DIFF
--- a/SyntaxKit/Pattern.swift
+++ b/SyntaxKit/Pattern.swift
@@ -55,21 +55,21 @@ class Pattern: NSObject {
         _name = dictionary["name"] as? String
 
         if let matchExpr = dictionary["match"] as? String {
-            _match = try? NSRegularExpression(pattern: matchExpr, options: [.anchorsMatchLines])
+            _match = try? NSRegularExpression.languagePattern(matchExpr, options: [.anchorsMatchLines])
             if debug && self.match == nil {
                 print("Problem parsing match expression \(matchExpr)")
             }
         }
 
         if let beginExpr = dictionary["begin"] as? String {
-            _begin = try? NSRegularExpression(pattern: beginExpr, options: [.anchorsMatchLines])
+            _begin = try? NSRegularExpression.languagePattern(beginExpr, options: [.anchorsMatchLines])
             if debug && self.begin == nil {
                 print("Problem parsing begin expression \(beginExpr)")
             }
         }
 
         if let endExpr = dictionary["end"] as? String {
-            _end = try? NSRegularExpression(pattern: endExpr, options: [.anchorsMatchLines])
+            _end = try? NSRegularExpression.languagePattern(endExpr, options: [.anchorsMatchLines])
             if debug && self.end == nil {
                 print("Problem parsing end expression \(endExpr)")
             }
@@ -240,3 +240,19 @@ class Include: Pattern {
         self.subpatterns = pattern.subpatterns
     }
 }
+
+fileprivate extension NSRegularExpression {
+    static func languagePattern(_ pattern: String, options: NSRegularExpression.Options) throws -> NSRegularExpression {
+        var realPattern = pattern
+        var realOptions = options
+        if let multilineOption = pattern.range(of:"(?x)"),
+            multilineOption.lowerBound == pattern.startIndex
+        {
+            realPattern = String(pattern.substring(from: multilineOption.upperBound))
+            realOptions.insert(.allowCommentsAndWhitespace)
+        }
+        
+        return try NSRegularExpression(pattern: realPattern, options: realOptions)
+    }
+}
+


### PR DESCRIPTION
Many regexes in popular `tmLanguage` files include multi-line patterns (examples below), which require a special regular expression mode to support. Some regex engines allow these to be specified using a leading `(?x)`, but `NSRegularExpression` instead requires an explicit flag to be set during initialization. This change recognizes regexes that start with `"(?x)"` and automatically sets the `.allowWhitespaceAndComments` flag for that regex.

The `NSRegularExpression.languagePattern()` function added here may seem like a good candidate to be a `convenience init` method. That is how I originally implemented it; however, a bug in Swift 3.1 causes that pattern to crash if given an invalid regex. (See https://bugs.swift.org/browse/SR-3637)

Examples of `tmLanguage` files that use the "(?x)" flag:
- https://github.com/textmate/c.tmbundle/blob/master/Syntaxes/C.plist
- https://github.com/textmate/objective-c.tmbundle/blob/master/Syntaxes/Objective-C.tmLanguage
- https://github.com/textmate/swift.tmbundle/blob/master/Syntaxes/Swift.tmLanguage
- https://github.com/bradrobertson/sublime-packages/blob/master/C%2B%2B/C%2B%2B.tmLanguage
- Etc. It's almost hard to find one out there that _doesn't_ include this option.